### PR TITLE
feat: implement complete CRUD operations for Joplin MCP server

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,21 @@ import logger from './lib/logger.js';
 
 import parseArgs from './lib/parse-args.js';
 import JoplinAPIClient from './lib/joplin-api-client.js';
-import { ListNotebooks, SearchNotes, ReadNotebook, ReadNote, ReadMultiNote } from './lib/tools/index.js';
+import { 
+  ListNotebooks, 
+  SearchNotes, 
+  ReadNotebook, 
+  ReadNote, 
+  ReadMultiNote,
+  CreateNote,
+  UpdateNote,
+  DeleteNote,
+  CreateFolder,
+  UpdateFolder,
+  DeleteFolder,
+  GetAllNotes,
+  GetFolder
+} from './lib/tools/index.js';
 
 // Parse command line arguments
 parseArgs();
@@ -108,6 +122,153 @@ server.tool(
   },
   {
     description: 'Read the full content of multiple notes at once'
+  }
+);
+
+// Register the create_note tool
+server.tool(
+  'create_note',
+  { 
+    title: z.string(),
+    body: z.string().optional(),
+    parent_id: z.string().optional(),
+    is_todo: z.boolean().optional(),
+    todo_due: z.number().optional()
+  },
+  async ({ title, body, parent_id, is_todo, todo_due }) => {
+    const result = await new CreateNote(apiClient).call(title, body, parent_id, is_todo, todo_due);
+    return {
+      content: [{ type: 'text', text: result }]
+    };
+  },
+  {
+    description: 'Create a new note with optional Markdown content, notebook assignment, and todo properties'
+  }
+);
+
+// Register the update_note tool
+server.tool(
+  'update_note',
+  { 
+    note_id: z.string(),
+    title: z.string().optional(),
+    body: z.string().optional(),
+    parent_id: z.string().optional(),
+    is_todo: z.boolean().optional(),
+    todo_completed: z.boolean().optional(),
+    todo_due: z.number().optional()
+  },
+  async ({ note_id, title, body, parent_id, is_todo, todo_completed, todo_due }) => {
+    const result = await new UpdateNote(apiClient).call(note_id, title, body, parent_id, is_todo, todo_completed, todo_due);
+    return {
+      content: [{ type: 'text', text: result }]
+    };
+  },
+  {
+    description: 'Update an existing note\'s title, content, notebook, or todo properties'
+  }
+);
+
+// Register the delete_note tool
+server.tool(
+  'delete_note',
+  { note_id: z.string() },
+  async ({ note_id }) => {
+    const result = await new DeleteNote(apiClient).call(note_id);
+    return {
+      content: [{ type: 'text', text: result }]
+    };
+  },
+  {
+    description: 'Move a note to trash (soft delete). The note can be restored from Joplin\'s trash'
+  }
+);
+
+// Register the create_folder tool
+server.tool(
+  'create_folder',
+  { 
+    title: z.string(),
+    parent_id: z.string().optional()
+  },
+  async ({ title, parent_id }) => {
+    const result = await new CreateFolder(apiClient).call(title, parent_id);
+    return {
+      content: [{ type: 'text', text: result }]
+    };
+  },
+  {
+    description: 'Create a new folder (notebook) with optional parent folder assignment'
+  }
+);
+
+// Register the update_folder tool
+server.tool(
+  'update_folder',
+  { 
+    folder_id: z.string(),
+    title: z.string().optional(),
+    parent_id: z.string().optional()
+  },
+  async ({ folder_id, title, parent_id }) => {
+    const result = await new UpdateFolder(apiClient).call(folder_id, title, parent_id);
+    return {
+      content: [{ type: 'text', text: result }]
+    };
+  },
+  {
+    description: 'Update a folder\'s title or move it to a different parent folder with circular reference prevention'
+  }
+);
+
+// Register the delete_folder tool
+server.tool(
+  'delete_folder',
+  { folder_id: z.string() },
+  async ({ folder_id }) => {
+    const result = await new DeleteFolder(apiClient).call(folder_id);
+    return {
+      content: [{ type: 'text', text: result }]
+    };
+  },
+  {
+    description: 'Move a folder and all its contents to trash (soft delete). Can be restored from Joplin\'s trash'
+  }
+);
+
+// Register the get_all_notes tool
+server.tool(
+  'get_all_notes',
+  { 
+    folder_id: z.string().optional(),
+    page: z.number().optional(),
+    limit: z.number().optional(),
+    order_by: z.string().optional(),
+    order_dir: z.string().optional()
+  },
+  async ({ folder_id, page, limit, order_by, order_dir }) => {
+    const result = await new GetAllNotes(apiClient).call(folder_id, page, limit, order_by, order_dir);
+    return {
+      content: [{ type: 'text', text: result }]
+    };
+  },
+  {
+    description: 'Get all notes with optional folder filtering, pagination, and sorting. Supports todo status display'
+  }
+);
+
+// Register the get_folder tool
+server.tool(
+  'get_folder',
+  { folder_id: z.string() },
+  async ({ folder_id }) => {
+    const result = await new GetFolder(apiClient).call(folder_id);
+    return {
+      content: [{ type: 'text', text: result }]
+    };
+  },
+  {
+    description: 'Get detailed information about a specific folder including contents summary and recent notes'
   }
 );
 

--- a/lib/tools/create-folder.js
+++ b/lib/tools/create-folder.js
@@ -1,0 +1,94 @@
+import { validateTitle, validateOptionalId } from '../validators.js';
+
+class CreateFolder {
+  constructor(apiClient) {
+    this.apiClient = apiClient;
+  }
+
+  async call(title, parentId) {
+    try {
+      // Validate inputs
+      validateTitle(title);
+      validateOptionalId(parentId, 'parent folder ID');
+
+      // Build request body
+      const requestBody = {
+        title: title.trim()
+      };
+
+      // Add parent_id if provided
+      if (parentId) {
+        requestBody.parent_id = parentId;
+      }
+
+      // Create the folder
+      const createdFolder = await this.apiClient.post('/folders', requestBody);
+
+      // Validate API response
+      if (!createdFolder || typeof createdFolder !== 'object' || !createdFolder.id) {
+        return `Error: Unexpected response format from Joplin API when creating folder`;
+      }
+
+      // Get parent folder info if applicable
+      let parentInfo = 'Root level';
+      if (createdFolder.parent_id) {
+        try {
+          const parentFolder = await this.apiClient.get(`/folders/${createdFolder.parent_id}`, {
+            query: { fields: 'id,title' }
+          });
+          if (parentFolder && parentFolder.title) {
+            parentInfo = `Inside "${parentFolder.title}" (${createdFolder.parent_id})`;
+          }
+        } catch (parentError) {
+          // Continue without parent info if we can't fetch it
+          parentInfo = `Inside parent folder (${createdFolder.parent_id})`;
+        }
+      }
+
+      // Format success response
+      const resultLines = [];
+      resultLines.push(`✅ Successfully created folder "${createdFolder.title}"`);
+      resultLines.push(`Folder ID: ${createdFolder.id}`);
+      resultLines.push(`Location: ${parentInfo}`);
+      resultLines.push(`Created: ${new Date(createdFolder.created_time).toLocaleString()}`);
+      
+      resultLines.push('');
+      resultLines.push('ℹ️  Folder Details:');
+      resultLines.push('- This folder can now contain notes and sub-folders');
+      resultLines.push('- Use this folder ID when creating notes to organize them');
+      
+      // Add helpful next steps
+      resultLines.push('');
+      resultLines.push('Next steps:');
+      resultLines.push(`- To view this folder: get_folder folder_id="${createdFolder.id}"`);
+      resultLines.push(`- To read folder contents: read_notebook notebook_id="${createdFolder.id}"`);
+      resultLines.push(`- To create a note in this folder: create_note title="note title" parent_id="${createdFolder.id}"`);
+      resultLines.push(`- To create a sub-folder: create_folder title="sub folder name" parent_id="${createdFolder.id}"`);
+      resultLines.push('- To see all folders: list_notebooks');
+
+      return resultLines.join('\n');
+
+    } catch (error) {
+      console.error('Error in create_folder:', error);
+      
+      // Handle specific HTTP status codes
+      if (error.response && error.response.status === 404) {
+        return `Error: Parent folder with ID "${parentId}" not found. Use list_notebooks to see available folders.`;
+      }
+      
+      if (error.response && error.response.status === 400) {
+        return `Error: Invalid request data. ${error.response.data?.error || 'Please check your input parameters.'}`;
+      }
+      
+      // Handle validation errors (from our validators)
+      if (error.message) {
+        return `Error: ${error.message}`;
+      }
+      
+      // Handle unknown errors
+      return `Error in create_folder: ${error.message || 'Unknown error'}`;
+    }
+  }
+}
+
+export default CreateFolder; 

--- a/lib/tools/create-note.js
+++ b/lib/tools/create-note.js
@@ -1,0 +1,115 @@
+import { 
+  validateTitle, 
+  validateOptionalId, 
+  validateOptionalBody, 
+  validateOptionalBoolean, 
+  validateOptionalTimestamp 
+} from '../validators.js';
+
+class CreateNote {
+  constructor(apiClient) {
+    this.apiClient = apiClient;
+  }
+
+  async call(title, body, parentId, isTodo, todoDue) {
+    try {
+      // Validate inputs
+      validateTitle(title);
+      validateOptionalId(parentId, 'notebook ID');
+      validateOptionalBody(body);
+      validateOptionalBoolean(isTodo, 'is_todo');
+      validateOptionalTimestamp(todoDue, 'todo_due');
+
+      // If is_todo is false but todo_due is provided, reject it
+      if (isTodo === false && todoDue !== undefined && todoDue !== null) {
+        throw new Error('todo_due cannot be set when is_todo is false.');
+      }
+
+      // Build request body
+      const requestBody = {
+        title: title.trim()
+      };
+
+      // Add optional fields if provided
+      if (body !== undefined && body !== null) {
+        requestBody.body = body;
+      }
+
+      if (parentId) {
+        requestBody.parent_id = parentId;
+      }
+
+      if (isTodo !== undefined && isTodo !== null) {
+        requestBody.is_todo = isTodo ? 1 : 0;
+      }
+
+      if (todoDue !== undefined && todoDue !== null) {
+        requestBody.todo_due = todoDue;
+      }
+
+      // Create the note
+      const createdNote = await this.apiClient.post('/notes', requestBody);
+
+      // Validate API response
+      if (!createdNote || typeof createdNote !== 'object' || !createdNote.id) {
+        return `Error: Unexpected response format from Joplin API when creating note`;
+      }
+
+      // Format success response
+      const resultLines = [];
+      resultLines.push(`✅ Successfully created note "${createdNote.title}"`);
+      resultLines.push(`Note ID: ${createdNote.id}`);
+      
+      if (createdNote.parent_id) {
+        resultLines.push(`Notebook ID: ${createdNote.parent_id}`);
+      } else {
+        resultLines.push(`Notebook: Default notebook`);
+      }
+
+      if (createdNote.is_todo) {
+        resultLines.push(`Type: Todo item`);
+        if (createdNote.todo_due) {
+          const dueDate = new Date(createdNote.todo_due).toLocaleString();
+          resultLines.push(`Due: ${dueDate}`);
+        }
+      } else {
+        resultLines.push(`Type: Regular note`);
+      }
+
+      resultLines.push(`Created: ${new Date(createdNote.created_time).toLocaleString()}`);
+      
+      // Add helpful next steps
+      resultLines.push('');
+      resultLines.push('Next steps:');
+      resultLines.push(`- To read this note: read_note note_id="${createdNote.id}"`);
+      if (createdNote.parent_id) {
+        resultLines.push(`- To view the notebook: read_notebook notebook_id="${createdNote.parent_id}"`);
+      }
+      resultLines.push(`- To update this note: update_note note_id="${createdNote.id}" title="new title" body="new content"`);
+
+      return resultLines.join('\n');
+
+    } catch (error) {
+      console.error('Error in create_note:', error);
+      
+      // Handle specific HTTP status codes
+      if (error.response && error.response.status === 404) {
+        return `Error: Notebook with ID "${parentId}" not found. Use list_notebooks to see available notebooks.`;
+      }
+      
+      if (error.response && error.response.status === 400) {
+        return `Error: Invalid request data. ${error.response.data?.error || 'Please check your input parameters.'}`;
+      }
+      
+      // Handle validation errors (from our validators)
+      if (error.message) {
+        return `Error: ${error.message}`;
+      }
+      
+      // Handle unknown errors
+      return `Error in create_note: ${error.message || 'Unknown error'}`;
+    }
+  }
+}
+
+export default CreateNote; 

--- a/lib/tools/delete-folder.js
+++ b/lib/tools/delete-folder.js
@@ -1,0 +1,139 @@
+import { validateFolderId } from '../validators.js';
+
+class DeleteFolder {
+  constructor(apiClient) {
+    this.apiClient = apiClient;
+  }
+
+  async call(folderId) {
+    try {
+      // Validate folder ID
+      validateFolderId(folderId);
+
+      // First, get the folder details for confirmation message
+      let folderTitle = 'Unknown folder';
+      let parentInfo = '';
+      let hasSubfolders = false;
+      let noteCount = 0;
+      
+      try {
+        const folder = await this.apiClient.get(`/folders/${folderId}`, {
+          query: { fields: 'id,title,parent_id' }
+        });
+        
+        if (folder && folder.title) {
+          folderTitle = folder.title;
+        }
+        
+        if (folder && folder.parent_id) {
+          // Try to get parent folder name for better confirmation
+          try {
+            const parentFolder = await this.apiClient.get(`/folders/${folder.parent_id}`, {
+              query: { fields: 'id,title' }
+            });
+            if (parentFolder && parentFolder.title) {
+              parentInfo = ` inside "${parentFolder.title}"`;
+            }
+          } catch (parentError) {
+            // Continue without parent info if we can't fetch it
+          }
+        }
+
+        // Check for subfolders and notes to provide better information
+        try {
+          // Get all folders to check for children
+          const allFolders = await this.apiClient.getAllItems('/folders', {
+            query: { fields: 'id,title,parent_id' }
+          });
+          
+          const subfolders = allFolders.filter(f => f.parent_id === folderId);
+          hasSubfolders = subfolders.length > 0;
+
+          // Get notes in this folder
+          const notes = await this.apiClient.get(`/folders/${folderId}/notes`, {
+            query: { fields: 'id' }
+          });
+          
+          if (notes && notes.items) {
+            noteCount = notes.items.length;
+          }
+        } catch (countError) {
+          // Continue without count info if we can't fetch it
+        }
+        
+      } catch (fetchError) {
+        // If we can't fetch the folder details, we'll still try to delete it
+        // The delete operation will return a proper 404 if the folder doesn't exist
+      }
+
+      // Delete the folder (soft delete - moves to trash)
+      await this.apiClient.delete(`/folders/${folderId}`);
+
+      // Format success response
+      const resultLines = [];
+      resultLines.push(`✅ Successfully moved folder "${folderTitle}" to trash`);
+      resultLines.push(`Folder ID: ${folderId}`);
+      
+      if (parentInfo) {
+        resultLines.push(`Location: ${parentInfo}`);
+      }
+      
+      resultLines.push('');
+      resultLines.push('ℹ️  Deletion Details:');
+      resultLines.push('- The folder has been moved to the trash (soft deleted)');
+      resultLines.push('- You can restore it from Joplin\'s trash if needed');
+      resultLines.push('- The folder is no longer accessible via the API');
+      
+      if (noteCount > 0) {
+        resultLines.push(`- ${noteCount} note(s) in this folder were also moved to trash`);
+      }
+      
+      if (hasSubfolders) {
+        resultLines.push('- Any sub-folders were also moved to trash');
+      }
+      
+      if (noteCount === 0 && !hasSubfolders) {
+        resultLines.push('- This folder was empty');
+      }
+      
+      resultLines.push('');
+      resultLines.push('⚠️  Important Notes:');
+      resultLines.push('- Deleting a folder also moves all its contents to trash');
+      resultLines.push('- This includes all notes and sub-folders within it');
+      resultLines.push('- Use the Joplin desktop app to restore if needed');
+      
+      resultLines.push('');
+      resultLines.push('Related commands:');
+      resultLines.push('- To see all folders: list_notebooks');
+      resultLines.push('- To create a new folder: create_folder title="folder name"');
+
+      return resultLines.join('\n');
+
+    } catch (error) {
+      console.error('Error in delete_folder:', error);
+      
+      // Handle specific HTTP status codes
+      if (error.response && error.response.status === 404) {
+        return `Error: Folder with ID "${folderId}" not found. The folder may have already been deleted or the ID is incorrect. Use list_notebooks to see available folders.`;
+      }
+      
+      if (error.response && error.response.status === 403) {
+        return `Error: Permission denied. You may not have permission to delete this folder.`;
+      }
+      
+      if (error.response && error.response.status === 400) {
+        return `Error: Invalid request. ${error.response.data?.error || 'Please check the folder ID format.'}`;
+      }
+      
+      // Handle validation errors (from our validators)
+      if (error.message) {
+        return `Error: ${error.message}`;
+      }
+      
+      // Handle unknown errors
+      return `Error in delete_folder: ${error.message || 'Unknown error'}`;
+    }
+  }
+}
+
+export default DeleteFolder; 

--- a/lib/tools/delete-note.js
+++ b/lib/tools/delete-note.js
@@ -1,0 +1,99 @@
+import { validateNoteId } from '../validators.js';
+
+class DeleteNote {
+  constructor(apiClient) {
+    this.apiClient = apiClient;
+  }
+
+  async call(noteId) {
+    try {
+      // Validate note ID
+      validateNoteId(noteId);
+
+      // First, get the note details for confirmation message
+      let noteTitle = 'Unknown note';
+      let notebookInfo = '';
+      
+      try {
+        const note = await this.apiClient.get(`/notes/${noteId}`, {
+          query: { fields: 'id,title,parent_id' }
+        });
+        
+        if (note && note.title) {
+          noteTitle = note.title;
+        }
+        
+        if (note && note.parent_id) {
+          // Try to get notebook name for better confirmation
+          try {
+            const notebook = await this.apiClient.get(`/folders/${note.parent_id}`, {
+              query: { fields: 'id,title' }
+            });
+            if (notebook && notebook.title) {
+              notebookInfo = ` from notebook "${notebook.title}"`;
+            }
+          } catch (notebookError) {
+            // Continue without notebook info if we can't fetch it
+          }
+        }
+      } catch (fetchError) {
+        // If we can't fetch the note details, we'll still try to delete it
+        // The delete operation will return a proper 404 if the note doesn't exist
+      }
+
+      // Delete the note (soft delete - moves to trash)
+      await this.apiClient.delete(`/notes/${noteId}`);
+
+      // Format success response
+      const resultLines = [];
+      resultLines.push(`✅ Successfully moved note "${noteTitle}" to trash`);
+      resultLines.push(`Note ID: ${noteId}`);
+      
+      if (notebookInfo) {
+        resultLines.push(`Location: ${notebookInfo}`);
+      }
+      
+      resultLines.push('');
+      resultLines.push('ℹ️  Note Details:');
+      resultLines.push('- The note has been moved to the trash (soft deleted)');
+      resultLines.push('- You can restore it from Joplin\'s trash if needed');
+      resultLines.push('- The note is no longer accessible via the API');
+      
+      resultLines.push('');
+      resultLines.push('Related commands:');
+      resultLines.push('- To see all notes: get_all_notes');
+      resultLines.push('- To search for notes: search_notes query="your search term"');
+      if (notebookInfo) {
+        resultLines.push('- To view remaining notes in this notebook: read_notebook notebook_id="notebook-id"');
+      }
+
+      return resultLines.join('\n');
+
+    } catch (error) {
+      console.error('Error in delete_note:', error);
+      
+      // Handle specific HTTP status codes
+      if (error.response && error.response.status === 404) {
+        return `Error: Note with ID "${noteId}" not found. The note may have already been deleted or the ID is incorrect. Use search_notes to find valid note IDs.`;
+      }
+      
+      if (error.response && error.response.status === 403) {
+        return `Error: Permission denied. You may not have permission to delete this note.`;
+      }
+      
+      if (error.response && error.response.status === 400) {
+        return `Error: Invalid request. ${error.response.data?.error || 'Please check the note ID format.'}`;
+      }
+      
+      // Handle validation errors (from our validators)
+      if (error.message) {
+        return `Error: ${error.message}`;
+      }
+      
+      // Handle unknown errors
+      return `Error in delete_note: ${error.message || 'Unknown error'}`;
+    }
+  }
+}
+
+export default DeleteNote; 

--- a/lib/tools/get-all-notes.js
+++ b/lib/tools/get-all-notes.js
@@ -1,0 +1,207 @@
+import { 
+  validateOptionalId, 
+  validatePaginationParams, 
+  validateOrderParams 
+} from '../validators.js';
+
+class GetAllNotes {
+  constructor(apiClient) {
+    this.apiClient = apiClient;
+  }
+
+  async call(folderId, page, limit, orderBy, orderDir) {
+    try {
+      // Validate inputs
+      validateOptionalId(folderId, 'folder ID');
+      validatePaginationParams(page, limit);
+      validateOrderParams(orderBy, orderDir);
+
+      // Set defaults
+      const actualPage = page || 1;
+      const actualLimit = Math.min(limit || 50, 100); // Cap at 100
+      const actualOrderBy = orderBy || 'updated_time';
+      const actualOrderDir = (orderDir || 'DESC').toUpperCase();
+
+      // Build query parameters
+      const queryParams = {
+        fields: 'id,title,parent_id,is_todo,todo_completed,todo_due,created_time,updated_time,user_created_time,user_updated_time',
+        page: actualPage,
+        limit: actualLimit,
+        order_by: actualOrderBy,
+        order_dir: actualOrderDir
+      };
+
+      // Add folder filter if specified
+      if (folderId) {
+        queryParams.parent_id = folderId;
+      }
+
+      // Get the notes
+      const response = await this.apiClient.get('/notes', { query: queryParams });
+
+      // Validate API response
+      if (!response || typeof response !== 'object') {
+        return `Error: Unexpected response format from Joplin API when getting notes`;
+      }
+
+      const notes = response.items || [];
+      const hasMore = response.has_more || false;
+
+      // If no notes found
+      if (notes.length === 0) {
+        const resultLines = [];
+        if (folderId) {
+          resultLines.push(`📝 No notes found in the specified folder`);
+          resultLines.push(`Folder ID: ${folderId}`);
+        } else {
+          resultLines.push(`📝 No notes found`);
+        }
+        
+        resultLines.push('');
+        resultLines.push('Suggestions:');
+        resultLines.push('- Create a new note: create_note title="my note"');
+        resultLines.push('- Search for notes: search_notes query="search term"');
+        resultLines.push('- List all folders: list_notebooks');
+        
+        return resultLines.join('\n');
+      }
+
+      // Get folder names for display
+      const folderCache = new Map();
+      
+      // Collect unique folder IDs
+      const folderIds = [...new Set(notes.map(note => note.parent_id).filter(id => id))];
+      
+      // Fetch folder names in batch if possible
+      if (folderIds.length > 0) {
+        try {
+          for (const id of folderIds) {
+            try {
+              const folder = await this.apiClient.get(`/folders/${id}`, {
+                query: { fields: 'id,title' }
+              });
+              if (folder && folder.title) {
+                folderCache.set(id, folder.title);
+              }
+            } catch (folderError) {
+              // Continue without folder name if we can't fetch it
+            }
+          }
+        } catch (error) {
+          // Continue without folder names if batch fetch fails
+        }
+      }
+
+      // Format success response
+      const resultLines = [];
+      
+      // Header with summary
+      if (folderId) {
+        const folderName = folderCache.get(folderId) || 'Unknown folder';
+        resultLines.push(`📝 Notes in "${folderName}" (${notes.length} of ${response.total || notes.length})`);
+        resultLines.push(`Folder ID: ${folderId}`);
+      } else {
+        resultLines.push(`📝 All Notes (${notes.length} of ${response.total || notes.length})`);
+      }
+      
+      resultLines.push(`Page: ${actualPage}, Limit: ${actualLimit}`);
+      resultLines.push(`Sorted by: ${actualOrderBy} ${actualOrderDir}`);
+      resultLines.push('');
+
+      // List notes
+      notes.forEach((note, index) => {
+        const noteLines = [];
+        noteLines.push(`${index + 1}. "${note.title}"`);
+        noteLines.push(`   ID: ${note.id}`);
+        
+        // Show folder if not filtering by folder
+        if (!folderId && note.parent_id) {
+          const folderName = folderCache.get(note.parent_id) || note.parent_id;
+          noteLines.push(`   Folder: ${folderName}`);
+        }
+
+        // Show todo status
+        if (note.is_todo) {
+          const status = note.todo_completed ? 'Completed' : 'Not completed';
+          noteLines.push(`   Todo: ${status}`);
+          
+          if (note.todo_due) {
+            const dueDate = new Date(note.todo_due).toLocaleString();
+            noteLines.push(`   Due: ${dueDate}`);
+          }
+        }
+
+        // Show dates
+        noteLines.push(`   Updated: ${new Date(note.updated_time).toLocaleString()}`);
+        
+        resultLines.push(noteLines.join('\n'));
+        
+        // Add spacing between notes
+        if (index < notes.length - 1) {
+          resultLines.push('');
+        }
+      });
+
+      // Add pagination info
+      if (hasMore || actualPage > 1) {
+        resultLines.push('');
+        resultLines.push('📄 Pagination:');
+        
+        if (actualPage > 1) {
+          const prevPage = actualPage - 1;
+          const prevCommand = this.buildCommand(folderId, prevPage, actualLimit, actualOrderBy, actualOrderDir);
+          resultLines.push(`   Previous: ${prevCommand}`);
+        }
+        
+        if (hasMore) {
+          const nextPage = actualPage + 1;
+          const nextCommand = this.buildCommand(folderId, nextPage, actualLimit, actualOrderBy, actualOrderDir);
+          resultLines.push(`   Next: ${nextCommand}`);
+        }
+      }
+
+      // Add helpful commands
+      resultLines.push('');
+      resultLines.push('Related commands:');
+      resultLines.push('- To read a note: read_note note_id="note-id"');
+      resultLines.push('- To search notes: search_notes query="search term"');
+      resultLines.push('- To create a note: create_note title="note title"');
+
+      return resultLines.join('\n');
+
+    } catch (error) {
+      console.error('Error in get_all_notes:', error);
+      
+      // Handle specific HTTP status codes
+      if (error.response && error.response.status === 404) {
+        return `Error: Folder with ID "${folderId}" not found. Use list_notebooks to see available folders.`;
+      }
+      
+      if (error.response && error.response.status === 400) {
+        return `Error: Invalid request parameters. ${error.response.data?.error || 'Please check your parameters.'}`;
+      }
+      
+      // Handle validation errors (from our validators)
+      if (error.message) {
+        return `Error: ${error.message}`;
+      }
+      
+      // Handle unknown errors
+      return `Error in get_all_notes: ${error.message || 'Unknown error'}`;
+    }
+  }
+
+  buildCommand(folderId, page, limit, orderBy, orderDir) {
+    const parts = ['get_all_notes'];
+    
+    if (folderId) parts.push(`folder_id="${folderId}"`);
+    if (page !== 1) parts.push(`page=${page}`);
+    if (limit !== 50) parts.push(`limit=${limit}`);
+    if (orderBy !== 'updated_time') parts.push(`order_by="${orderBy}"`);
+    if (orderDir !== 'DESC') parts.push(`order_dir="${orderDir}"`);
+    
+    return parts.join(' ');
+  }
+}
+
+export default GetAllNotes; 

--- a/lib/tools/get-folder.js
+++ b/lib/tools/get-folder.js
@@ -1,0 +1,179 @@
+import { validateFolderId } from '../validators.js';
+
+class GetFolder {
+  constructor(apiClient) {
+    this.apiClient = apiClient;
+  }
+
+  async call(folderId) {
+    try {
+      // Validate folder ID
+      validateFolderId(folderId);
+
+      // Get the folder details
+      const folder = await this.apiClient.get(`/folders/${folderId}`, {
+        query: { fields: 'id,title,parent_id,created_time,updated_time,user_created_time,user_updated_time' }
+      });
+
+      // Validate API response
+      if (!folder || typeof folder !== 'object' || !folder.id) {
+        return `Error: Unexpected response format from Joplin API when getting folder`;
+      }
+
+      // Get parent folder info if applicable
+      let parentInfo = 'Root level';
+      if (folder.parent_id) {
+        try {
+          const parentFolder = await this.apiClient.get(`/folders/${folder.parent_id}`, {
+            query: { fields: 'id,title' }
+          });
+          if (parentFolder && parentFolder.title) {
+            parentInfo = `"${parentFolder.title}" (${folder.parent_id})`;
+          }
+        } catch (parentError) {
+          // Continue without parent info if we can't fetch it
+          parentInfo = `Parent folder (${folder.parent_id})`;
+        }
+      }
+
+      // Get sub-folders
+      let subfolders = [];
+      try {
+        const allFolders = await this.apiClient.getAllItems('/folders', {
+          query: { fields: 'id,title,created_time' }
+        });
+        subfolders = allFolders.filter(f => f.parent_id === folderId);
+        // Sort by title
+        subfolders.sort((a, b) => a.title.localeCompare(b.title));
+      } catch (subfoldersError) {
+        // Continue without subfolder info if we can't fetch it
+      }
+
+      // Get notes count and recent notes
+      let noteCount = 0;
+      let recentNotes = [];
+      try {
+        const notesResponse = await this.apiClient.get(`/folders/${folderId}/notes`, {
+          query: { 
+            fields: 'id,title,is_todo,todo_completed,updated_time',
+            limit: 5,
+            order_by: 'updated_time',
+            order_dir: 'DESC'
+          }
+        });
+        
+        if (notesResponse && notesResponse.items) {
+          noteCount = notesResponse.total || notesResponse.items.length;
+          recentNotes = notesResponse.items;
+        }
+      } catch (notesError) {
+        // Continue without notes info if we can't fetch it
+      }
+
+      // Format success response
+      const resultLines = [];
+      
+      // Header
+      resultLines.push(`📁 Folder: "${folder.title}"`);
+      resultLines.push(`ID: ${folder.id}`);
+      resultLines.push(`Location: ${parentInfo}`);
+      
+      // Timestamps
+      resultLines.push(`Created: ${new Date(folder.created_time).toLocaleString()}`);
+      resultLines.push(`Updated: ${new Date(folder.updated_time).toLocaleString()}`);
+      
+      resultLines.push('');
+      
+      // Contents summary
+      resultLines.push('📊 Contents Summary:');
+      resultLines.push(`- Notes: ${noteCount}`);
+      resultLines.push(`- Sub-folders: ${subfolders.length}`);
+      
+      // Sub-folders list
+      if (subfolders.length > 0) {
+        resultLines.push('');
+        resultLines.push('📁 Sub-folders:');
+        subfolders.forEach((subfolder, index) => {
+          resultLines.push(`   ${index + 1}. "${subfolder.title}" (${subfolder.id})`);
+        });
+      }
+
+      // Recent notes
+      if (recentNotes.length > 0) {
+        resultLines.push('');
+        resultLines.push('📝 Recent Notes:');
+        recentNotes.forEach((note, index) => {
+          const noteLines = [];
+          noteLines.push(`   ${index + 1}. "${note.title}"`);
+          noteLines.push(`      ID: ${note.id}`);
+          
+          if (note.is_todo) {
+            const status = note.todo_completed ? 'Completed' : 'Not completed';
+            noteLines.push(`      Todo: ${status}`);
+          }
+          
+          noteLines.push(`      Updated: ${new Date(note.updated_time).toLocaleString()}`);
+          
+          resultLines.push(noteLines.join('\n'));
+        });
+        
+        if (noteCount > recentNotes.length) {
+          resultLines.push(`   ... and ${noteCount - recentNotes.length} more notes`);
+        }
+      }
+
+      // Helpful commands
+      resultLines.push('');
+      resultLines.push('🔧 Related Commands:');
+      resultLines.push(`- View all contents: read_notebook notebook_id="${folder.id}"`);
+      resultLines.push(`- Get all notes in folder: get_all_notes folder_id="${folder.id}"`);
+      resultLines.push(`- Create note in folder: create_note title="note title" parent_id="${folder.id}"`);
+      resultLines.push(`- Create sub-folder: create_folder title="sub folder" parent_id="${folder.id}"`);
+      resultLines.push(`- Update folder: update_folder folder_id="${folder.id}" title="new name"`);
+      
+      if (folder.parent_id) {
+        resultLines.push(`- View parent folder: get_folder folder_id="${folder.parent_id}"`);
+      }
+      
+      // Navigation commands
+      if (subfolders.length > 0) {
+        resultLines.push('');
+        resultLines.push('📁 Navigate to sub-folders:');
+        subfolders.slice(0, 3).forEach(subfolder => {
+          resultLines.push(`- get_folder folder_id="${subfolder.id}"`);
+        });
+        if (subfolders.length > 3) {
+          resultLines.push(`- ... and ${subfolders.length - 3} more sub-folders`);
+        }
+      }
+
+      return resultLines.join('\n');
+
+    } catch (error) {
+      console.error('Error in get_folder:', error);
+      
+      // Handle specific HTTP status codes
+      if (error.response && error.response.status === 404) {
+        return `Error: Folder with ID "${folderId}" not found. Use list_notebooks to see available folders.`;
+      }
+      
+      if (error.response && error.response.status === 403) {
+        return `Error: Permission denied. You may not have permission to access this folder.`;
+      }
+      
+      if (error.response && error.response.status === 400) {
+        return `Error: Invalid request. ${error.response.data?.error || 'Please check the folder ID format.'}`;
+      }
+      
+      // Handle validation errors (from our validators)
+      if (error.message) {
+        return `Error: ${error.message}`;
+      }
+      
+      // Handle unknown errors
+      return `Error in get_folder: ${error.message || 'Unknown error'}`;
+    }
+  }
+}
+
+export default GetFolder; 

--- a/lib/tools/index.js
+++ b/lib/tools/index.js
@@ -4,10 +4,35 @@ import ReadNotebook from './read-notebook.js';
 import ReadNote from './read-note.js';
 import ReadMultiNote from './read-multi-note.js';
 
+// New CRUD and GET tools
+import CreateNote from './create-note.js';
+import UpdateNote from './update-note.js';
+import DeleteNote from './delete-note.js';
+import CreateFolder from './create-folder.js';
+import UpdateFolder from './update-folder.js';
+import DeleteFolder from './delete-folder.js';
+import GetAllNotes from './get-all-notes.js';
+import GetFolder from './get-folder.js';
+
 export {
+  // Existing tools
   ListNotebooks,
   SearchNotes,
   ReadNotebook,
   ReadNote,
-  ReadMultiNote
+  ReadMultiNote,
+  
+  // New note CRUD tools
+  CreateNote,
+  UpdateNote,
+  DeleteNote,
+  
+  // New folder CRUD tools
+  CreateFolder,
+  UpdateFolder,
+  DeleteFolder,
+  
+  // New GET tools
+  GetAllNotes,
+  GetFolder
 };

--- a/lib/tools/update-folder.js
+++ b/lib/tools/update-folder.js
@@ -1,0 +1,163 @@
+import { 
+  validateFolderId, 
+  validateOptionalTitle, 
+  validateOptionalId,
+  validateAtLeastOneUpdateField 
+} from '../validators.js';
+
+class UpdateFolder {
+  constructor(apiClient) {
+    this.apiClient = apiClient;
+  }
+
+  async call(folderId, title, parentId) {
+    try {
+      // Validate folder ID
+      validateFolderId(folderId);
+
+      // Validate optional parameters
+      validateOptionalTitle(title);
+      validateOptionalId(parentId, 'parent folder ID');
+
+      // Validate at least one field is provided for update
+      const updateFields = { title, parentId };
+      validateAtLeastOneUpdateField(updateFields);
+
+      // Check for circular reference (folder cannot be its own descendant)
+      if (parentId && parentId !== folderId) {
+        await this.checkCircularReference(folderId, parentId);
+      }
+
+      // If trying to move folder to itself, prevent it
+      if (parentId === folderId) {
+        throw new Error('A folder cannot be moved to itself.');
+      }
+
+      // Build request body with only provided fields
+      const requestBody = {};
+
+      if (title !== undefined && title !== null && title !== '') {
+        requestBody.title = title.trim();
+      }
+
+      if (parentId !== undefined && parentId !== null && parentId !== '') {
+        requestBody.parent_id = parentId;
+      }
+
+      // Update the folder
+      const updatedFolder = await this.apiClient.put(`/folders/${folderId}`, requestBody);
+
+      // Validate API response
+      if (!updatedFolder || typeof updatedFolder !== 'object' || !updatedFolder.id) {
+        return `Error: Unexpected response format from Joplin API when updating folder`;
+      }
+
+      // Get parent folder info if applicable
+      let parentInfo = 'Root level';
+      if (updatedFolder.parent_id) {
+        try {
+          const parentFolder = await this.apiClient.get(`/folders/${updatedFolder.parent_id}`, {
+            query: { fields: 'id,title' }
+          });
+          if (parentFolder && parentFolder.title) {
+            parentInfo = `Inside "${parentFolder.title}" (${updatedFolder.parent_id})`;
+          }
+        } catch (parentError) {
+          // Continue without parent info if we can't fetch it
+          parentInfo = `Inside parent folder (${updatedFolder.parent_id})`;
+        }
+      }
+
+      // Format success response
+      const resultLines = [];
+      resultLines.push(`✅ Successfully updated folder "${updatedFolder.title}"`);
+      resultLines.push(`Folder ID: ${updatedFolder.id}`);
+      resultLines.push(`Location: ${parentInfo}`);
+      resultLines.push(`Last updated: ${new Date(updatedFolder.updated_time).toLocaleString()}`);
+      
+      // Show what was updated
+      const updatedFields = [];
+      if (requestBody.title) updatedFields.push('title');
+      if (requestBody.parent_id !== undefined) updatedFields.push('location');
+      
+      if (updatedFields.length > 0) {
+        resultLines.push(`Updated fields: ${updatedFields.join(', ')}`);
+      }
+      
+      // Add helpful next steps
+      resultLines.push('');
+      resultLines.push('Next steps:');
+      resultLines.push(`- To view this folder: get_folder folder_id="${updatedFolder.id}"`);
+      resultLines.push(`- To read folder contents: read_notebook notebook_id="${updatedFolder.id}"`);
+      resultLines.push('- To see all folders: list_notebooks');
+
+      return resultLines.join('\n');
+
+    } catch (error) {
+      console.error('Error in update_folder:', error);
+      
+      // Handle specific HTTP status codes
+      if (error.response && error.response.status === 404) {
+        return `Error: Folder with ID "${folderId}" not found. Use list_notebooks to see available folders.`;
+      }
+      
+      if (error.response && error.response.status === 400) {
+        return `Error: Invalid request data. ${error.response.data?.error || 'Please check your input parameters.'}`;
+      }
+      
+      // Handle validation errors (from our validators)
+      if (error.message) {
+        return `Error: ${error.message}`;
+      }
+      
+      // Handle unknown errors
+      return `Error in update_folder: ${error.message || 'Unknown error'}`;
+    }
+  }
+
+  /**
+   * Check if moving folderId to parentId would create a circular reference
+   * This prevents a folder from becoming its own descendant
+   */
+  async checkCircularReference(folderId, parentId) {
+    const visitedIds = new Set();
+    let currentParentId = parentId;
+
+    while (currentParentId) {
+      // If we've already visited this ID, we have a cycle
+      if (visitedIds.has(currentParentId)) {
+        throw new Error('Circular reference detected in folder hierarchy.');
+      }
+
+      // If the parent we're checking is the folder we're trying to move, it's circular
+      if (currentParentId === folderId) {
+        throw new Error('Cannot move folder to be its own descendant.');
+      }
+
+      visitedIds.add(currentParentId);
+
+      try {
+        // Get the parent of the current folder
+        const folder = await this.apiClient.get(`/folders/${currentParentId}`, {
+          query: { fields: 'id,parent_id' }
+        });
+        
+        currentParentId = folder.parent_id;
+        
+        // If parent_id is null or empty, we've reached the root
+        if (!currentParentId) {
+          break;
+        }
+      } catch (error) {
+        // If we can't fetch a folder, it might not exist
+        if (error.response && error.response.status === 404) {
+          throw new Error(`Parent folder with ID "${currentParentId}" not found.`);
+        }
+        // For other errors, let them bubble up
+        throw error;
+      }
+    }
+  }
+}
+
+export default UpdateFolder; 

--- a/lib/tools/update-note.js
+++ b/lib/tools/update-note.js
@@ -1,0 +1,144 @@
+import { 
+  validateNoteId, 
+  validateOptionalTitle, 
+  validateOptionalId, 
+  validateOptionalBody, 
+  validateOptionalBoolean, 
+  validateOptionalTimestamp,
+  validateAtLeastOneUpdateField 
+} from '../validators.js';
+
+class UpdateNote {
+  constructor(apiClient) {
+    this.apiClient = apiClient;
+  }
+
+  async call(noteId, title, body, parentId, isTodo, todoCompleted, todoDue) {
+    try {
+      // Validate note ID
+      validateNoteId(noteId);
+
+      // Validate optional parameters
+      validateOptionalTitle(title);
+      validateOptionalId(parentId, 'notebook ID');
+      validateOptionalBody(body);
+      validateOptionalBoolean(isTodo, 'is_todo');
+      validateOptionalBoolean(todoCompleted, 'todo_completed');
+      validateOptionalTimestamp(todoDue, 'todo_due');
+
+      // Validate at least one field is provided for update
+      const updateFields = { title, body, parentId, isTodo, todoCompleted, todoDue };
+      validateAtLeastOneUpdateField(updateFields);
+
+      // Build request body with only provided fields
+      const requestBody = {};
+
+      if (title !== undefined && title !== null && title !== '') {
+        requestBody.title = title.trim();
+      }
+
+      if (body !== undefined && body !== null) {
+        requestBody.body = body;
+      }
+
+      if (parentId !== undefined && parentId !== null && parentId !== '') {
+        requestBody.parent_id = parentId;
+      }
+
+      if (isTodo !== undefined && isTodo !== null) {
+        requestBody.is_todo = isTodo ? 1 : 0;
+      }
+
+      if (todoCompleted !== undefined && todoCompleted !== null) {
+        requestBody.todo_completed = todoCompleted ? Date.now() : 0;
+      }
+
+      if (todoDue !== undefined && todoDue !== null) {
+        requestBody.todo_due = todoDue;
+      }
+
+      // Update the note
+      const updatedNote = await this.apiClient.put(`/notes/${noteId}`, requestBody);
+
+      // Validate API response
+      if (!updatedNote || typeof updatedNote !== 'object' || !updatedNote.id) {
+        return `Error: Unexpected response format from Joplin API when updating note`;
+      }
+
+      // Format success response
+      const resultLines = [];
+      resultLines.push(`✅ Successfully updated note "${updatedNote.title}"`);
+      resultLines.push(`Note ID: ${updatedNote.id}`);
+      
+      if (updatedNote.parent_id) {
+        resultLines.push(`Notebook ID: ${updatedNote.parent_id}`);
+      } else {
+        resultLines.push(`Notebook: Default notebook`);
+      }
+
+      if (updatedNote.is_todo) {
+        const status = updatedNote.todo_completed ? 'Completed' : 'Not completed';
+        resultLines.push(`Type: Todo item (${status})`);
+        
+        if (updatedNote.todo_due) {
+          const dueDate = new Date(updatedNote.todo_due).toLocaleString();
+          resultLines.push(`Due: ${dueDate}`);
+        }
+        
+        if (updatedNote.todo_completed) {
+          const completedDate = new Date(updatedNote.todo_completed).toLocaleString();
+          resultLines.push(`Completed: ${completedDate}`);
+        }
+      } else {
+        resultLines.push(`Type: Regular note`);
+      }
+
+      resultLines.push(`Last updated: ${new Date(updatedNote.updated_time).toLocaleString()}`);
+      
+      // Show what was updated
+      const updatedFields = [];
+      if (requestBody.title) updatedFields.push('title');
+      if (requestBody.body !== undefined) updatedFields.push('content');
+      if (requestBody.parent_id) updatedFields.push('notebook');
+      if (requestBody.is_todo !== undefined) updatedFields.push('todo status');
+      if (requestBody.todo_completed !== undefined) updatedFields.push('completion status');
+      if (requestBody.todo_due !== undefined) updatedFields.push('due date');
+      
+      if (updatedFields.length > 0) {
+        resultLines.push(`Updated fields: ${updatedFields.join(', ')}`);
+      }
+      
+      // Add helpful next steps
+      resultLines.push('');
+      resultLines.push('Next steps:');
+      resultLines.push(`- To read this note: read_note note_id="${updatedNote.id}"`);
+      if (updatedNote.parent_id) {
+        resultLines.push(`- To view the notebook: read_notebook notebook_id="${updatedNote.parent_id}"`);
+      }
+
+      return resultLines.join('\n');
+
+    } catch (error) {
+      console.error('Error in update_note:', error);
+      
+      // Handle specific HTTP status codes
+      if (error.response && error.response.status === 404) {
+        return `Error: Note with ID "${noteId}" not found. Use search_notes to find valid note IDs.`;
+      }
+      
+      if (error.response && error.response.status === 400) {
+        return `Error: Invalid request data. ${error.response.data?.error || 'Please check your input parameters.'}`;
+      }
+      
+      // Handle validation errors (from our validators)
+      if (error.message) {
+        return `Error: ${error.message}`;
+      }
+      
+      // Handle unknown errors
+      return `Error in update_note: ${error.message || 'Unknown error'}`;
+    }
+  }
+}
+
+export default UpdateNote; 

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -1,0 +1,109 @@
+/**
+ * Validation utilities for Joplin MCP server tools
+ * These validators throw exceptions that will be caught by tool methods
+ */
+
+export function validateNoteId(id) {
+  if (!id || typeof id !== 'string' || id.length !== 32 || !id.match(/^[a-f0-9]{32}$/i)) {
+    throw new Error('Invalid note ID format. Must be 32-character hexadecimal string.');
+  }
+}
+
+export function validateFolderId(id) {
+  if (!id || typeof id !== 'string' || id.length !== 32 || !id.match(/^[a-f0-9]{32}$/i)) {
+    throw new Error('Invalid folder ID format. Must be 32-character hexadecimal string.');
+  }
+}
+
+export function validateTitle(title) {
+  if (!title || typeof title !== 'string' || title.trim().length === 0) {
+    throw new Error('Title is required and cannot be empty.');
+  }
+  if (title.length > 255) {
+    throw new Error('Title cannot exceed 255 characters.');
+  }
+}
+
+export function validateOptionalId(id, type = 'ID') {
+  if (id !== undefined && id !== null && id !== '') {
+    if (typeof id !== 'string' || id.length !== 32 || !id.match(/^[a-f0-9]{32}$/i)) {
+      throw new Error(`Invalid ${type} format. Must be 32-character hexadecimal string.`);
+    }
+  }
+}
+
+export function validateOptionalTitle(title) {
+  if (title !== undefined && title !== null && title !== '') {
+    if (typeof title !== 'string') {
+      throw new Error('Title must be a string.');
+    }
+    if (title.length > 255) {
+      throw new Error('Title cannot exceed 255 characters.');
+    }
+  }
+}
+
+export function validateOptionalBody(body) {
+  if (body !== undefined && body !== null) {
+    if (typeof body !== 'string') {
+      throw new Error('Note body must be a string.');
+    }
+  }
+}
+
+export function validateOptionalBoolean(value, fieldName) {
+  if (value !== undefined && value !== null) {
+    if (typeof value !== 'boolean') {
+      throw new Error(`${fieldName} must be a boolean (true/false).`);
+    }
+  }
+}
+
+export function validateOptionalTimestamp(timestamp, fieldName) {
+  if (timestamp !== undefined && timestamp !== null) {
+    if (typeof timestamp !== 'number' || timestamp < 0) {
+      throw new Error(`${fieldName} must be a valid Unix timestamp (positive number).`);
+    }
+  }
+}
+
+export function validatePaginationParams(page, limit) {
+  if (page !== undefined && page !== null) {
+    if (typeof page !== 'number' || page < 1) {
+      throw new Error('Page must be a positive number starting from 1.');
+    }
+  }
+  
+  if (limit !== undefined && limit !== null) {
+    if (typeof limit !== 'number' || limit < 1 || limit > 100) {
+      throw new Error('Limit must be a number between 1 and 100.');
+    }
+  }
+}
+
+export function validateOrderParams(orderBy, orderDir) {
+  const validOrderFields = ['id', 'title', 'created_time', 'updated_time', 'user_created_time', 'user_updated_time'];
+  const validOrderDirections = ['ASC', 'DESC'];
+  
+  if (orderBy !== undefined && orderBy !== null && orderBy !== '') {
+    if (typeof orderBy !== 'string' || !validOrderFields.includes(orderBy)) {
+      throw new Error(`Order by must be one of: ${validOrderFields.join(', ')}`);
+    }
+  }
+  
+  if (orderDir !== undefined && orderDir !== null && orderDir !== '') {
+    if (typeof orderDir !== 'string' || !validOrderDirections.includes(orderDir.toUpperCase())) {
+      throw new Error(`Order direction must be ASC or DESC`);
+    }
+  }
+}
+
+export function validateAtLeastOneUpdateField(fields) {
+  const definedFields = Object.keys(fields).filter(key => 
+    fields[key] !== undefined && fields[key] !== null && fields[key] !== ''
+  );
+  
+  if (definedFields.length === 0) {
+    throw new Error('At least one property must be provided for update.');
+  }
+} 


### PR DESCRIPTION
- Add 8 new tools: create_note, update_note, delete_note, create_folder, update_folder, delete_folder, get_all_notes, get_folder
- Implement comprehensive input validation system (lib/validators.js)
- Add full CRUD functionality for notes with Markdown and todo support
- Add hierarchical folder operations with circular reference prevention
- Implement soft delete operations (move to trash, recoverable)
- Add pagination and filtering for note listings
- Include detailed folder information with contents summary
- Provide user-friendly error handling and response formatting
- Follow MCP protocol standards for proper error propagation
- Add comprehensive tool registration with Zod schemas

All tools tested and verified working with real Joplin instance. Resolves requirements for note/folder CRUD operations and additional GET functionality.