### PR TITLE
Feature/lazy authentication: No need for an initial .env due to temporary configuration page after server launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ JOPLIN_TOKEN=your_joplin_token
 You can find your Joplin token in the Joplin desktop app under:
 Tools > Options > Web Clipper
 
+**Lazy Authentication**: The server can now start without `JOPLIN_TOKEN` explicitly set. If a tool requiring authentication is used without a token, the server will provide a link to a local web interface (default: `http://localhost:3000/auth`) where you can securely input and save your token.
+
 ## Usage
 
 Start the server:
@@ -257,6 +259,134 @@ Successfully retrieved: 3
 ```
 
 > **Tip**: When you search for notes or view a notebook, you'll see a suggestion for using `read_multinote` with the exact IDs of the notes found. This makes it easy to read multiple related notes at once.
+
+### create_note
+
+Create a new note with optional Markdown content, notebook assignment, and todo properties.
+
+**Parameters:**
+- `title`: Title of the note
+- `body` (optional): Markdown content
+- `parent_id` (optional): ID of the parent notebook
+- `is_todo` (optional): Boolean, true if it's a todo
+- `todo_due` (optional): Timestamp for due date
+
+```
+# Example usage:
+create_note title="New Task" is_todo=true body="# Details"
+```
+
+### update_note
+
+Update an existing note's title, content, notebook, or todo properties.
+
+**Parameters:**
+- `note_id`: ID of the note to update
+- `title` (optional)
+- `body` (optional)
+- `parent_id` (optional)
+- `is_todo` (optional)
+- `todo_completed` (optional)
+- `todo_due` (optional)
+
+```
+# Example usage:
+update_note note_id="abc123" title="Updated Task" todo_completed=true
+```
+
+### delete_note
+
+Move a note to trash (soft delete). The note can be restored from Joplin's trash.
+
+**Parameters:**
+- `note_id`: ID of the note to delete
+
+```
+# Example usage:
+delete_note note_id="abc123"
+```
+
+### create_folder
+
+Create a new folder (notebook) with optional parent folder assignment.
+
+**Parameters:**
+- `title`: Title of the folder
+- `parent_id` (optional): ID of the parent folder
+
+```
+# Example usage:
+create_folder title="My Project"
+```
+
+### update_folder
+
+Update a folder's title or move it to a different parent folder with circular reference prevention.
+
+**Parameters:**
+- `folder_id`: ID of the folder to update
+- `title` (optional)
+- `parent_id` (optional)
+
+```
+# Example usage:
+update_folder folder_id="xyz789" title="Renamed Project"
+```
+
+### delete_folder
+
+Move a folder and all its contents to trash (soft delete). Can be restored from Joplin's trash.
+
+**Parameters:**
+- `folder_id`: ID of the folder to delete
+
+```
+# Example usage:
+delete_folder folder_id="xyz789"
+```
+
+### get_all_notes
+
+Get all notes with optional folder filtering, pagination, and sorting. Supports todo status display.
+
+**Parameters:**
+- `folder_id` (optional)
+- `page` (optional)
+- `limit` (optional)
+- `order_by` (optional)
+- `order_dir` (optional)
+
+```
+# Example usage:
+get_all_notes folder_id="xyz789" limit=20
+```
+
+### get_folder
+
+Get detailed information about a specific folder including contents summary and recent notes.
+
+**Parameters:**
+- `folder_id`: ID of the folder
+
+```
+# Example usage:
+get_folder folder_id="xyz789"
+```
+
+### clip_from_url
+
+Fetch a URL, convert its content to Markdown using Joplin's internal clipper, and save it as a new note.
+
+**Parameters:**
+- `url`: The URL to clip
+- `notebook_id` (optional): Destination notebook ID
+- `tags` (optional): Comma-separated tags
+- `title` (optional): Note title (will extract from page if omitted)
+
+```
+# Example usage:
+clip_from_url url="https://joplinapp.org" tags="joplin,research"
+```
 
 ## Development
 

--- a/index.js
+++ b/index.js
@@ -39,8 +39,7 @@ const authManager = new AuthManager({
   configPath: envFilePath
 });
 
-// Start the auth server (it will be available if needed)
-authManager.start();
+// Auth server will start automatically when authentication fails
 
 // Check for required environment variables (only JOPLIN_PORT is strictly required now)
 if (!process.env.JOPLIN_PORT && !authManager.joplinPort) {

--- a/index.js
+++ b/index.js
@@ -30,12 +30,13 @@ import {
 import { ClipUrlTool } from './lib/tools/clip-url.js';
 
 // Parse command line arguments
-parseArgs();
+const { envFilePath } = parseArgs();
 
 // Initialize Auth Manager
 const authManager = new AuthManager({
   port: 3000, // Default auth server port
-  joplinPort: process.env.JOPLIN_PORT || 41184
+  joplinPort: process.env.JOPLIN_PORT || 41184,
+  configPath: envFilePath
 });
 
 // Start the auth server (it will be available if needed)
@@ -280,9 +281,9 @@ server.tool(
   }
 );
 
-// Register the clip_url tool
+// Register the clip_from_url tool
 server.tool(
-  'clip_url',
+  'clip_from_url',
   { 
     url: z.string(),
     notebook_id: z.string().optional(),
@@ -296,7 +297,7 @@ server.tool(
     };
   },
   {
-    description: 'Fetch a URL, convert its content to Markdown using Joplin\'s internal clipper, and save it as a new note'
+    description: 'Fetch a URL, convert its content to Markdown using Joplin\'s internal web clipper, and save it as a new note'
   }
 );
 

--- a/lib/auth-manager.js
+++ b/lib/auth-manager.js
@@ -1,0 +1,163 @@
+import fs from 'fs';
+import path from 'path';
+import express from 'express';
+import axios from 'axios';
+import logger from './logger.js';
+
+class AuthManager {
+  constructor(options = {}) {
+    this.port = options.port || 3000;
+    this.joplinPort = options.joplinPort || 41184;
+    this.configPath = options.configPath || path.join(process.cwd(), '.env');
+    this.token = null;
+    this.app = express();
+    this.server = null;
+    
+    // Initialize
+    this.loadToken();
+    this.setupServer();
+  }
+
+  loadToken() {
+    // Try to load from process.env first (priority)
+    if (process.env.JOPLIN_TOKEN) {
+      this.token = process.env.JOPLIN_TOKEN;
+      return;
+    }
+
+    // Try to load from .env file
+    if (fs.existsSync(this.configPath)) {
+      const content = fs.readFileSync(this.configPath, 'utf8');
+      const match = content.match(/JOPLIN_TOKEN=(.*)/);
+      if (match && match[1]) {
+        this.token = match[1].trim();
+      }
+    }
+  }
+
+  getToken() {
+    return this.token;
+  }
+
+  hasToken() {
+    return !!this.token;
+  }
+
+  async validateToken(token) {
+    try {
+      const response = await axios.get(`http://127.0.0.1:${this.joplinPort}/ping`, {
+        params: { token }
+      });
+      return response.data === 'JoplinClipperServer';
+    } catch (error) {
+      return false;
+    }
+  }
+
+  saveToken(token) {
+    this.token = token;
+    
+    // Update .env file
+    let content = '';
+    if (fs.existsSync(this.configPath)) {
+      content = fs.readFileSync(this.configPath, 'utf8');
+    }
+
+    if (content.includes('JOPLIN_TOKEN=')) {
+      content = content.replace(/JOPLIN_TOKEN=.*/, `JOPLIN_TOKEN=${token}`);
+    } else {
+      content += `\nJOPLIN_TOKEN=${token}`;
+    }
+
+    fs.writeFileSync(this.configPath, content);
+    
+    // Also update process.env for current session
+    process.env.JOPLIN_TOKEN = token;
+  }
+
+  setupServer() {
+    this.app.use(express.urlencoded({ extended: true }));
+    
+    this.app.get('/auth', (req, res) => {
+      const status = this.hasToken() ? '<p style="color: green">Token is configured!</p>' : '<p style="color: red">Token is missing</p>';
+      
+      res.send(`
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title>Joplin MCP Auth</title>
+          <style>
+            body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; max-width: 600px; margin: 40px auto; padding: 20px; }
+            input { padding: 10px; width: 100%; box-sizing: border-box; margin: 10px 0; }
+            button { padding: 10px 20px; background: #0066cc; color: white; border: none; cursor: pointer; }
+            button:hover { background: #0052a3; }
+            .error { color: red; }
+            .success { color: green; }
+          </style>
+        </head>
+        <body>
+          <h1>Joplin MCP Server Authentication</h1>
+          ${status}
+          <p>Please enter your Joplin Web Clipper Authorization Token.</p>
+          <p>You can find or generate this token in Joplin Desktop: <strong>Tools > Options > Web Clipper</strong></p>
+          
+          <form method="POST" action="/auth">
+            <input type="text" name="token" placeholder="Enter your Joplin API Token" required />
+            <button type="submit">Save Token</button>
+          </form>
+        </body>
+        </html>
+      `);
+    });
+
+    this.app.post('/auth', async (req, res) => {
+      const { token } = req.body;
+      
+      if (!token) {
+        return res.send('Token is required <a href="/auth">Try again</a>');
+      }
+
+      const isValid = await this.validateToken(token);
+      
+      if (isValid) {
+        this.saveToken(token);
+        res.send(`
+          <h1 style="color: green">Success!</h1>
+          <p>Token verified and saved successfully.</p>
+          <p>You can now close this window and return to your AI Assistant.</p>
+        `);
+      } else {
+        res.send(`
+          <h1 style="color: red">Invalid Token</h1>
+          <p>The provided token could not be verified with Joplin.</p>
+          <p>Please ensure Joplin is running and the Web Clipper service is enabled.</p>
+          <a href="/auth">Try again</a>
+        `);
+      }
+    });
+  }
+
+  start() {
+    // Try to find an available port if 3000 is taken, or just use a fixed range
+    // For simplicity, we'll try 3000, then fall back to random
+    this.server = this.app.listen(this.port, () => {
+      logger.info(`Auth server listening at http://localhost:${this.port}/auth`);
+    }).on('error', (err) => {
+      if (err.code === 'EADDRINUSE') {
+        // Try a random port
+        this.server = this.app.listen(0, () => {
+          this.port = this.server.address().port;
+          logger.info(`Auth server listening at http://localhost:${this.port}/auth`);
+        });
+      } else {
+        logger.error('Failed to start auth server:', err);
+      }
+    });
+  }
+
+  getAuthUrl() {
+    return `http://localhost:${this.port}/auth`;
+  }
+}
+
+export default AuthManager;

--- a/lib/auth-manager.js
+++ b/lib/auth-manager.js
@@ -126,6 +126,8 @@ class AuthManager {
           <p>Token verified and saved successfully.</p>
           <p>You can now close this window and return to your AI Assistant.</p>
         `);
+        // Close the auth server after successful token validation
+        setTimeout(() => this.stop(), 1000);
       } else {
         res.send(`
           <h1 style="color: red">Invalid Token</h1>
@@ -138,6 +140,11 @@ class AuthManager {
   }
 
   start() {
+    // Don't start if already running
+    if (this.server && this.server.listening) {
+      return;
+    }
+
     // Try to find an available port if 3000 is taken, or just use a fixed range
     // For simplicity, we'll try 3000, then fall back to random
     this.server = this.app.listen(this.port, () => {
@@ -153,6 +160,25 @@ class AuthManager {
         logger.error('Failed to start auth server:', err);
       }
     });
+  }
+
+  stop() {
+    if (this.server && this.server.listening) {
+      this.server.close(() => {
+        logger.info('Auth server stopped');
+      });
+      this.server = null;
+    }
+  }
+
+  ensureStarted() {
+    if (!this.server || !this.server.listening) {
+      this.start();
+    }
+  }
+
+  isRunning() {
+    return this.server && this.server.listening;
   }
 
   getAuthUrl() {

--- a/lib/joplin-api-client.js
+++ b/lib/joplin-api-client.js
@@ -12,6 +12,10 @@ class JoplinAPIClient {
 
   handleAuthError(error) {
     if (error.response && (error.response.status === 401 || error.response.status === 403)) {
+      // Start the auth server if not already running
+      if (this.authManager) {
+        this.authManager.ensureStarted();
+      }
       const authUrl = this.authManager ? this.authManager.getAuthUrl() : 'unknown';
       throw new Error(`Joplin API token is missing or invalid. Please configure it by visiting: ${authUrl}`);
     }

--- a/lib/joplin-api-client.js
+++ b/lib/joplin-api-client.js
@@ -1,9 +1,21 @@
 import axios from 'axios';
 
 class JoplinAPIClient {
-  constructor({ port = 41184, token }) {
+  constructor({ port = 41184, authManager }) {
     this.baseURL = `http://127.0.0.1:${port}`;
-    this.token = token;
+    this.authManager = authManager;
+  }
+
+  get token() {
+    return this.authManager ? this.authManager.getToken() : null;
+  }
+
+  handleAuthError(error) {
+    if (error.response && (error.response.status === 401 || error.response.status === 403)) {
+      const authUrl = this.authManager ? this.authManager.getAuthUrl() : 'unknown';
+      throw new Error(`Joplin API token is missing or invalid. Please configure it by visiting: ${authUrl}`);
+    }
+    throw error;
   }
 
   async serviceAvailable() {
@@ -52,8 +64,11 @@ class JoplinAPIClient {
       );
       return data;
     } catch (error) {
-      console.error(`Error in GET request for path ${path}:`, error);
-      throw error;
+      // Don't log auth errors to console, they are handled gracefully
+      if (!error.response || (error.response.status !== 401 && error.response.status !== 403)) {
+        console.error(`Error in GET request for path ${path}:`, error);
+      }
+      this.handleAuthError(error);
     }
   }
 
@@ -68,8 +83,10 @@ class JoplinAPIClient {
       );
       return data;
     } catch (error) {
-      console.error(`Error in POST request for path ${path}:`, error);
-      throw error;
+      if (!error.response || (error.response.status !== 401 && error.response.status !== 403)) {
+        console.error(`Error in POST request for path ${path}:`, error);
+      }
+      this.handleAuthError(error);
     }
   }
 
@@ -83,8 +100,10 @@ class JoplinAPIClient {
       );
       return data;
     } catch (error) {
-      console.error(`Error in DELETE request for path ${path}:`, error);
-      throw error;
+      if (!error.response || (error.response.status !== 401 && error.response.status !== 403)) {
+        console.error(`Error in DELETE request for path ${path}:`, error);
+      }
+      this.handleAuthError(error);
     }
   }
 
@@ -99,9 +118,26 @@ class JoplinAPIClient {
       );
       return data;
     } catch (error) {
-      console.error(`Error in PUT request for path ${path}:`, error);
-      throw error;
+      if (!error.response || (error.response.status !== 401 && error.response.status !== 403)) {
+        console.error(`Error in PUT request for path ${path}:`, error);
+      }
+      this.handleAuthError(error);
     }
+  }
+
+  async clipPage(url, html, title, parentId, tags) {
+    // Mimic Joplin Web Clipper behavior
+    const body = {
+      title: title || 'New Note',
+      body_html: html,
+      source_url: url,
+      convert_to: 'markdown'
+    };
+
+    if (parentId) body.parent_id = parentId;
+    if (tags) body.tags = tags;
+
+    return this.post('/notes', body);
   }
 
   requestOptions(options = {}) {

--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -7,6 +7,7 @@ const __dirname = dirname(__filename);
 
 function parseArgs() {
   const args = process.argv.slice(2);
+  let envFilePath = null;
   
   if (args.includes('--env-file')) {
     const envFileIndex = args.indexOf('--env-file');
@@ -15,14 +16,15 @@ function parseArgs() {
     // Remove the --env-file and its value from args
     args.splice(envFileIndex, 2);
     
+    envFilePath = resolve(process.cwd(), envFile);
     // Load the environment variables from the specified file
-    dotenv.config({ path: resolve(process.cwd(), envFile) });
+    dotenv.config({ path: envFilePath });
   } else {
     // Load from default .env file
     dotenv.config();
   }
   
-  return args;
+  return { args, envFilePath };
 }
 
 export default parseArgs;

--- a/lib/tools/clip-url.js
+++ b/lib/tools/clip-url.js
@@ -1,0 +1,45 @@
+import axios from 'axios';
+
+class ClipUrlTool {
+  constructor(apiClient) {
+    this.apiClient = apiClient;
+  }
+
+  async call(url, notebook_id, tags, title) {
+    try {
+      // 1. Fetch the HTML content
+      const response = await axios.get(url, {
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+        }
+      });
+      
+      const html = response.data;
+
+      // 2. Extract title if not provided
+      let noteTitle = title;
+      if (!noteTitle) {
+        const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i);
+        noteTitle = titleMatch ? titleMatch[1].trim() : 'Clipped Note';
+      }
+
+      // 3. Send to Joplin
+      const result = await this.apiClient.clipPage(
+        url,
+        html,
+        noteTitle,
+        notebook_id,
+        tags
+      );
+
+      return `Successfully clipped "${noteTitle}" to Joplin!\nNote ID: ${result.id}\nView Note: [Open in Joplin](joplin://x-callback-url/openNote?id=${result.id})`;
+    } catch (error) {
+      if (error.message && error.message.includes('Joplin API token is missing')) {
+        throw error; // Re-throw auth errors as-is
+      }
+      throw new Error(`Failed to clip URL: ${error.message}`);
+    }
+  }
+}
+
+export { ClipUrlTool };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@modelcontextprotocol/sdk": "^1.8.0",
     "axios": "^1.6.7",
     "dotenv": "^16.4.5",
+    "express": "^5.1.0",
     "zod": "^3.23.8"
   }
 }


### PR DESCRIPTION
This PR adds lazy authentication support, building on top of the web clipping functionality from #[Feature/clip from url: A new tool for adding notes from web urls #3]. A temporary page with a text input field for token setting gets offered by a local mini server if token authentication fails (also missing .env). The mini server shuts down endpoint again as soon as it succeeds. The server URL is returned in the fail-response for the LLM to mediate it to the user.

## Changes
- Added [AuthManager](/lib/auth-manager.js:6:0-186:1) class with Express-based local web interface for token input
- Modified [JoplinAPIClient](./lib/joplin-api-client.js:2:0-171:1) to use [AuthManager](./lib/auth-manager.js:6:0-186:1) for dynamic token retrieval
- Implemented on-demand auth server lifecycle:
  - Server starts automatically when authentication fails (401/403)
  - Server stops automatically after successful token validation (./lib/auth-manager.js:6:0-186:1)
- Added graceful error handling with auth server URL in error messages
- Updated README with lazy authentication documentation

## Implementation Details
- Auth server runs on port 3000 (falls back to random port if busy)
- Token is validated against Joplin API before saving
- Token persists in [.env]
- Server provides user-friendly web form at `http://localhost:3000/auth` (changes to random port if :3000 not available)

## Dependencies
- Subsumes all changes from PR#3(web clipping functionality)
- Adds `express` dependency for auth server
